### PR TITLE
replace --command option and change cli to accept a path for —script option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,13 @@ If you'd like to pass in a filepath to be watched, it can be passed directly to 
 
 You can [use globs](https://github.com/micromatch/picomatch), or pass in multiple, space-separated paths to be watched as well.
 
-
 ### Optional Flags
 
-| Option | Shorthand | Example | Description | Default |
-| --- | --- | --- | --- | --- |
-| `--root` | `-r` | `--root ./src` | Path to Nextjs project | `process.cwd()` |
-| `--event` | `-e` | `--event add` | Specific event to listen for (`add`, `addDir`, `change`, `unlink`, `unlinkDir` | `change`
-| `--command` | `-c` | `--command 'node ./scripts/sync.js'` | Command to be called on `event` with two arguments (`path`, `event`).
-
+| Option     | Shorthand | Example                      | Description                                                                    | Default         |
+| ---------- | --------- | ---------------------------- | ------------------------------------------------------------------------------ | --------------- |
+| `--root`   | `-r`      | `--root ./src`               | Path to Nextjs project                                                         | `process.cwd()` |
+| `--event`  | `-e`      | `--event add`                | Specific event to listen for (`add`, `addDir`, `change`, `unlink`, `unlinkDir` | `change`        |
+| `--script` | `-c`      | `--script ./scripts/sync.js` | File to be called on `event` with two arguments (`path`, `event`).             |
 
 ### The Magic Reload URL
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can [use globs](https://github.com/micromatch/picomatch), or pass in multipl
 | --- | --- | --- | --- | --- |
 | `--root` | `-r` | `--root ./src` | Path to Nextjs project | `process.cwd()` |
 | `--event` | `-e` | `--event add` | Specific event to listen for (`add`, `addDir`, `change`, `unlink`, `unlinkDir` | `change`
-| `--command` | `-c` | `--command node ./scripts/sync.js` | Command to be called on `event` with two arguments (`path`, `event`).
+| `--command` | `-c` | `--command 'node ./scripts/sync.js'` | Command to be called on `event` with two arguments (`path`, `event`).
 
 
 ### The Magic Reload URL

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can [use globs](https://github.com/micromatch/picomatch), or pass in multipl
 | ---------- | --------- | ---------------------------- | ------------------------------------------------------------------------------ | --------------- |
 | `--root`   | `-r`      | `--root ./src`               | Path to Nextjs project                                                         | `process.cwd()` |
 | `--event`  | `-e`      | `--event add`                | Specific event to listen for (`add`, `addDir`, `change`, `unlink`, `unlinkDir` | `change`        |
-| `--script` | `-s`      | `--script ./scripts/sync.js` | File to be called on `event` with two arguments (`path`, `event`).             |
+| `--script` | `-s`      | `--script ./scripts/sync.js` | Node script to be called on `event`. The file should export a function that accepts two arguments (`path`, `event`).             |
 
 ### The Magic Reload URL
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can [use globs](https://github.com/micromatch/picomatch), or pass in multipl
 | ---------- | --------- | ---------------------------- | ------------------------------------------------------------------------------ | --------------- |
 | `--root`   | `-r`      | `--root ./src`               | Path to Nextjs project                                                         | `process.cwd()` |
 | `--event`  | `-e`      | `--event add`                | Specific event to listen for (`add`, `addDir`, `change`, `unlink`, `unlinkDir` | `change`        |
-| `--script` | `-c`      | `--script ./scripts/sync.js` | File to be called on `event` with two arguments (`path`, `event`).             |
+| `--script` | `-s`      | `--script ./scripts/sync.js` | File to be called on `event` with two arguments (`path`, `event`).             |
 
 ### The Magic Reload URL
 

--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -9,15 +9,23 @@ const { parse } = require('url')
 const chokidar = require('chokidar')
 const next = require('next')
 const { promisify } = require('util')
-const exec = promisify(require('child_process').exec)
+const path = require('path')
 
 const defaultWatchEvent = 'change'
 
 program.version(pkg.version)
 program
   .option('-r, --root [dir]', 'root directory of your nextjs app')
-  .option('-c, --command [cmd]', 'command to trigger on watch event', false)
-  .option('-e, --event [name]', `name of event to watch, defaults to ${defaultWatchEvent}`, defaultWatchEvent)
+  .option(
+    '-s, --script [path]',
+    'path to the script you want to trigger on a watcher event',
+    false
+  )
+  .option(
+    '-e, --event [name]',
+    `name of event to watch, defaults to ${defaultWatchEvent}`,
+    defaultWatchEvent
+  )
   .parse(process.argv)
 
 const app = next({ dev: true, dir: program.root || process.cwd() })
@@ -27,26 +35,36 @@ const handle = app.getRequestHandler()
 app.prepare().then(() => {
   // if directories are provided, watch them for changes and trigger reload
   if (program.args.length > 0) {
-    chokidar.watch(program.args).on(program.event, async (path, event = defaultWatchEvent) => {
-      app.hotReloader.send('building')
+    chokidar
+      .watch(program.args)
+      .on(
+        program.event,
+        async (filePathContext, eventContext = defaultWatchEvent) => {
+          app.hotReloader.send('building')
 
-      if (program.command) {
-        try {
-          const { stdout, stderr } = await exec(`${program.command} ${path} ${event}`)
-          console.log(stdout)
+          if (program.script) {
+            try {
+              // find the path of your --script script
+              const scriptPath = path.join(
+                process.cwd(),
+                program.script.toString()
+              )
 
-          if (stderr) {
-            throw stderr
+              // require your --script script
+              const executeFile = require(scriptPath)
+
+              // run the exported function from your --comand script
+              executeFile(filePathContext, eventContext)
+            } catch (e) {
+              console.error('Remote script failed')
+              console.error(e)
+              return e
+            }
           }
-        } catch (e) {
-          console.error('Remote command failed')
-          console.error(e)
-          return e
-        }
-      }
 
-      app.hotReloader.send('reloadPage')
-    })
+          app.hotReloader.send('reloadPage')
+        }
+      )
   }
 
   // create an express server

--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -53,7 +53,7 @@ app.prepare().then(() => {
               // require your --script script
               const executeFile = require(scriptPath)
 
-              // run the exported function from your --comand script
+              // run the exported function from your --script script
               executeFile(filePathContext, eventContext)
             } catch (e) {
               console.error('Remote script failed')

--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -33,12 +33,11 @@ app.prepare().then(() => {
       if (program.command) {
         try {
           const { stdout, stderr } = await exec(`${program.command} ${path} ${event}`)
+          console.log(stdout)
+
           if (stderr) {
             throw stderr
           }
-
-          console.log(stdout)
-
         } catch (e) {
           console.error('Remote command failed')
           console.error(e)

--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -8,7 +8,6 @@ const chalk = require('chalk')
 const { parse } = require('url')
 const chokidar = require('chokidar')
 const next = require('next')
-const { promisify } = require('util')
 const path = require('path')
 
 const defaultWatchEvent = 'change'

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "index.js",
   "scripts": {
     "test": "./bin/next-remote-watch test/remote/* -r test/next-app/",
-    "test:command": "./bin/next-remote-watch test/remote/* -r test/next-app/ -c 'npm run sync --prefix test/next-app --'",
-    "test:event": "./bin/next-remote-watch test/remote/* -r test/next-app/ -e unlink",
     "release:major": "release major && npm publish",
     "release:minor": "release minor && npm publish",
-    "release:patch": "release patch && npm publish"
+    "release:patch": "release patch && npm publish",
+    "test:event": "./bin/next-remote-watch test/remote/* -r test/next-app/ -e unlink",
+    "test:script": "./bin/next-remote-watch test/remote/* -r test/next-app/ -s test/next-app/sync.js"
   },
   "bin": {
     "next-remote-watch": "./bin/next-remote-watch"

--- a/test/next-app/sync.js
+++ b/test/next-app/sync.js
@@ -1,6 +1,5 @@
-const path = process.argv[2]
-const event = process.argv[3]
-
-console.log('hello from sync script')
-console.log(`path: ${path}`)
-console.log(`event: ${event}`)
+module.exports = function (path, event) {
+  console.log('welcome from sync script')
+  console.log('file effected: ', path)
+  console.log('event: ', event)
+}


### PR DESCRIPTION
⚠️ includes some of will's commits because i originally based it on his `tweaks` branch. if any of his stuff is extra, it'll be blown away when we squash + merge.

#### description

we previously accepted a `—command` but instead now we accept a path to a `--script` option which we `require()` and we execute the function it exports. 

the CLI interface looks like this now:

```shell
next-remote-watch --script test/next-app/sync.js 
next-remote-watch -s test/next-app/sync.js # alt syntax
```

#### to test
- run `npm run test:script`
- make a change to `test/remote/foo.txt` 
- and you'll see our `test/next-app/sync.js` script fire 

<img width="255" alt="image" src="https://user-images.githubusercontent.com/49507/81759278-457a4b00-9492-11ea-811b-097c6d88963c.png">
