### PR TITLE
Add polling option to watcher

### DIFF
--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -25,6 +25,11 @@ program
     `name of event to watch, defaults to ${defaultWatchEvent}`,
     defaultWatchEvent
   )
+  .option(
+    '-p, --polling [name]',
+    `use polling for the watcher, defaults to false`,
+    false
+  )
   .parse(process.argv)
 
 const app = next({ dev: true, dir: program.root || process.cwd() })
@@ -35,7 +40,7 @@ app.prepare().then(() => {
   // if directories are provided, watch them for changes and trigger reload
   if (program.args.length > 0) {
     chokidar
-      .watch(program.args)
+      .watch(program.args, { usePolling: Boolean(program.polling) })
       .on(
         program.event,
         async (filePathContext, eventContext = defaultWatchEvent) => {


### PR DESCRIPTION
This PR adds the [`usePolling` option for `chokidar`](https://github.com/paulmillr/chokidar#performance) via a new flag: `-p, --polling`

When testing locally this improved the watcher immensely on my end.
