### PR TITLE
Fix issue with POST requests to `/api` routes

### DIFF
--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -73,10 +73,11 @@ app.prepare().then(() => {
 
   // create an express server
   const server = express()
-  server.use(bodyParser.json())
 
   // special handling for mdx reload route
-  server.all('/__next_reload', (req, res) => {
+  const reloadRoute = express.Router()
+  reloadRoute.use(bodyParser.json())
+  reloadRoute.all('/', (req, res) => {
     // log message if present
     const msg = req.body.message
     const color = req.body.color
@@ -87,6 +88,8 @@ app.prepare().then(() => {
     app.hotReloader.send('reloadPage')
     res.end('Reload initiated')
   })
+
+  server.use('/__next_reload', reloadRoute)
 
   // handle all other routes with next.js
   server.all('*', (req, res) => handle(req, res, parse(req.url, true)))


### PR DESCRIPTION
This PR fixes an issue with `POST` requests to Next `/api` routes, by limiting the custom server's `body-parser` use to the `/__next_reload` route.

## Details

Currently, `next-remote-watch`'s custom server uses `bodyParser.json()` on **all** routes, include routes that are ultimately forwarded to `next`. This causes issues with POST requests to `/api` routes.

Limiting `body-parser` to `/__next_reload` ensures we can still post `{ message, color }` data to that route, while cleanly forwarding requests to `next`'s `handler` without modifications.

## Background

As part of [work on a dynamic usage component for `react-components`](https://github.com/hashicorp/react-components/pull/88), I tried to create an `/api` route that receive `POST`'ed JSON data. But these POST requests weren't being returned.

It seems that using `next dev` directly rather than `next-remote-watch` resolved the issue. It also seems that removing `bodyParser.json()` middleware from `next-remote-watch` resolved the issue. Moving `bodyParser.json()` to only run on the `/__next_reload` route seems to properly fix the issue, while maintaining all other functionality.