### PR TITLE
To remove error when having _middleware

### DIFF
--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -37,9 +37,11 @@ program
   .parse(process.argv)
 
 const shell = process.env.SHELL
-const app = next({ dev: true, dir: program.root || process.cwd() })
 const port = parseInt(process.env.PORT, 10) || 3000
+const app = next({ dev: true, dir: program.root || process.cwd(), hostname: 'localhost', port })
 const handle = app.getRequestHandler()
+const handle = app.getRequestHandler()
+
 
 app.prepare().then(() => {
   // if directories are provided, watch them for changes and trigger reload


### PR DESCRIPTION
This is to remove an error when having _middleware, this issue:

https://github.com/hashicorp/next-remote-watch/issues/37