### PR TITLE
Next 13 support

### DIFF
--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -128,6 +128,6 @@ app.prepare().then(async () => {
   // fire it up
   server.listen(port, (err) => {
     if (err) throw err
-    console.log(`> Ready on http://localhost:${port}`)
+    console.log(`> Ready on http://${hostname}:${port}`)
   })
 })

--- a/bin/next-remote-watch
+++ b/bin/next-remote-watch
@@ -49,7 +49,9 @@ const app = next({
 })
 const handle = app.getRequestHandler()
 
-app.prepare().then(() => {
+app.prepare().then(async () => {
+  const appServer = app.server || await app.getServer();
+
   // if directories are provided, watch them for changes and trigger reload
   if (program.args.length > 0) {
     chokidar
@@ -57,7 +59,7 @@ app.prepare().then(() => {
       .on(
         program.event,
         async (filePathContext, eventContext = defaultWatchEvent) => {
-          app.server.hotReloader.send('building')
+          appServer.hotReloader.send('building')
 
           if (program.command) {
             // Use spawn here so that we can pipe stdio from the command without buffering
@@ -95,7 +97,7 @@ app.prepare().then(() => {
             }
           }
 
-          app.server.hotReloader.send('reloadPage')
+          appServer.hotReloader.send('reloadPage')
         }
       )
   }
@@ -113,8 +115,8 @@ app.prepare().then(() => {
     msg && console.log(color ? chalk[color](msg) : msg)
 
     // reload the nextjs app
-    app.server.hotReloader.send('building')
-    app.server.hotReloader.send('reloadPage')
+    appServer.hotReloader.send('building')
+    appServer.hotReloader.send('reloadPage')
     res.end('Reload initiated')
   })
 


### PR DESCRIPTION
I was getting the following error when using a fresh blog-starter template

```
- error unhandledRejection: TypeError: Cannot read properties of undefined (reading 'hotReloader')
    at FSWatcher.<anonymous> (/home/morantron/hacking/portfolio/node_modules/next-remote-watch/bin/next-remote-watch:60:22)
    at FSWatcher.emit (node:events:511:28)
    at FSWatcher.emitWithAll (/home/morantron/hacking/portfolio/node_modules/chokidar/index.js:540:8)
    at FSWatcher._emit (/home/morantron/hacking/portfolio/node_modules/chokidar/index.js:632:8)
    at listener (/home/morantron/hacking/portfolio/node_modules/chokidar/lib/nodefs-handler.js:370:20)
```

This change fixes it 👯 
